### PR TITLE
Implement initial il2cpp hook

### DIFF
--- a/module/src/main/cpp/CMakeLists.txt
+++ b/module/src/main/cpp/CMakeLists.txt
@@ -36,6 +36,8 @@ aux_source_directory(xdl xdl-src)
 add_library(${MODULE_NAME} SHARED
         main.cpp
         hack.cpp
+        hook_loader.cpp
+        dumper.cpp
         il2cpp_dump.cpp
         ${xdl-src})
 target_link_libraries(${MODULE_NAME} log)

--- a/module/src/main/cpp/dumper.cpp
+++ b/module/src/main/cpp/dumper.cpp
@@ -1,0 +1,42 @@
+#include "dumper.h"
+#include <cstdio>
+#include <cstdarg>
+#include <string>
+#include <fstream>
+#include "log.h"
+
+static const char *dump_path = "/data/local/tmp/redteam/il2cpp-dump.json";
+static const char *log_path = "/data/local/tmp/dump.log";
+
+static FILE *log_fp = nullptr;
+
+static void open_log() {
+    if (!log_fp) {
+        log_fp = fopen(log_path, "a");
+    }
+}
+
+static void log_print(const char *fmt, ...) {
+    va_list args;
+    va_start(args, fmt);
+    __android_log_vprint(ANDROID_LOG_INFO, LOG_TAG, fmt, args);
+    if (log_fp) {
+        vfprintf(log_fp, fmt, args);
+        fprintf(log_fp, "\n");
+        fflush(log_fp);
+    }
+    va_end(args);
+}
+
+void dump_registrations(void *code_reg, void *metadata_reg) {
+    open_log();
+    log_print("CodeRegistration=%p MetadataRegistration=%p", code_reg, metadata_reg);
+    std::ofstream out(dump_path);
+    if (!out.is_open()) {
+        log_print("Failed to open dump file %s", dump_path);
+        return;
+    }
+    out << "{\n  \"CodeRegistration\": \"" << code_reg << "\",\n";
+    out << "  \"MetadataRegistration\": \"" << metadata_reg << "\"\n}";
+    out.close();
+}

--- a/module/src/main/cpp/dumper.h
+++ b/module/src/main/cpp/dumper.h
@@ -1,0 +1,3 @@
+#pragma once
+#include <cstdint>
+void dump_registrations(void *code_reg, void *metadata_reg);

--- a/module/src/main/cpp/hook_loader.cpp
+++ b/module/src/main/cpp/hook_loader.cpp
@@ -1,0 +1,30 @@
+#include "hook_loader.h"
+#include "dumper.h"
+#include "xdl.h"
+#include "log.h"
+
+static int (*orig_il2cpp_init)(const char *domain_name) = nullptr;
+
+static int hooked_il2cpp_init(const char *domain_name) {
+    int ret = 0;
+    if (orig_il2cpp_init) {
+        ret = orig_il2cpp_init(domain_name);
+    }
+    void *handle = xdl_open("libil2cpp.so", 0);
+    if (handle) {
+        void *code_reg = xdl_sym(handle, "g_CodeRegistration", nullptr);
+        void *metadata_reg = xdl_sym(handle, "g_MetadataRegistration", nullptr);
+        dump_registrations(code_reg, metadata_reg);
+        xdl_close(handle);
+    } else {
+        LOGW("failed to open libil2cpp.so");
+    }
+    return ret;
+}
+
+void setup_il2cpp_hook(zygisk::Api *api) {
+    api->pltHookRegister("libil2cpp.so", "il2cpp_init", (void *)hooked_il2cpp_init, (void **)&orig_il2cpp_init);
+    if (!api->pltHookCommit()) {
+        LOGE("pltHookCommit failed");
+    }
+}

--- a/module/src/main/cpp/hook_loader.h
+++ b/module/src/main/cpp/hook_loader.h
@@ -1,0 +1,4 @@
+#pragma once
+#include "zygisk.hpp"
+
+void setup_il2cpp_hook(zygisk::Api *api);

--- a/module/src/main/cpp/main.cpp
+++ b/module/src/main/cpp/main.cpp
@@ -10,6 +10,7 @@
 #include "zygisk.hpp"
 #include "game.h"
 #include "log.h"
+#include "hook_loader.h"
 
 using zygisk::Api;
 using zygisk::AppSpecializeArgs;
@@ -51,6 +52,7 @@ private:
             enable_hack = true;
             game_data_dir = new char[strlen(app_data_dir) + 1];
             strcpy(game_data_dir, app_data_dir);
+            setup_il2cpp_hook(api);
 
 #if defined(__i386__)
             auto path = "zygisk/armeabi-v7a.so";


### PR DESCRIPTION
## Summary
- add dumper and hook loader helpers
- hook `il2cpp_init` when the game process starts
- dump CodeRegistration and MetadataRegistration pointers to `/data/local/tmp/redteam/il2cpp-dump.json`
- update build files to include new sources

## Testing
- `./gradlew assembleDebug` *(fails: Unsupported class file major version 65)*

------
https://chatgpt.com/codex/tasks/task_b_684d99814e2c8323959ffffd2c853769